### PR TITLE
Fix/updateuser

### DIFF
--- a/functions/src/logic/authLogic.ts
+++ b/functions/src/logic/authLogic.ts
@@ -23,16 +23,15 @@ export async function verifyUser(req: express.Request, res: express.Response) {
     .getUserAuth(username)
     .then(record => {
       // 400 if no matching record
+      console.log(record)
+      console.log(password)
       if (record === null) {
         return res.status(400).send("No user with username available");
+        
         // if password match, save token to auth collection
       } else if (`${password}` === record.obj.password) {
         return usersStorage
-          .updateUser(record.id)
-          .catch(err => {
-            console.error(err);
-            return res.status(500).send("Server Error");
-          })
+          .updateUser(record)
           .then(() => authStorage.createToken(record.id))
           .then(token => res.status(200).send({ token }))
           .catch(err => {

--- a/functions/src/logic/authLogic.ts
+++ b/functions/src/logic/authLogic.ts
@@ -23,8 +23,6 @@ export async function verifyUser(req: express.Request, res: express.Response) {
     .getUserAuth(username)
     .then(record => {
       // 400 if no matching record
-      console.log(record)
-      console.log(password)
       if (record === null) {
         return res.status(400).send("No user with username available");
         

--- a/functions/src/storage/usersStorage.ts
+++ b/functions/src/storage/usersStorage.ts
@@ -28,13 +28,14 @@ export async function readUsernames() {
  * @param uuid
  * @returns user object
  */
-export async function updateUser(uuid) {
-  const user = await readUser(uuid);
-  if (!user) throw Error("uuid is not related to any user")
+export async function updateUser(record) {
+  const user = await readUser(record.id);
+//   The culprite here for not creating a token and throwing the 500 error, maybe just log that a new user was created? - Dylan
+//   if (!user) throw Error("uuid is not related to any user")
   return db
     .collection("users")
-    .doc(`${uuid}`)
-    .set({"username": user.username, "last_login": Date.now()})
+    .doc(`${record.id}`)
+    .set({username: record.obj.username, last_login: Date.now()},{ merge: true })
 }
 
 /**


### PR DESCRIPTION
Users present in auth collection now get written to or updated in users collection. Removed unnecessary catch and silenced a thrown error that caused 500 status if user had not been created in users collection.